### PR TITLE
feat: Add option to disable connection keep alive on asset downloading

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,52 +85,55 @@ Call `npx storyblok-backup` with the following options:
 #### Backup options
 
 ```text
---token <token>       (required) Personal OAuth access token created
-                      in the account settings of a Stoyblok user.
-                      (NOT the Access Token of a Space!)
-                      Alternatively, you can set the STORYBLOK_OAUTH_TOKEN environment variable.
---space <space_id>    (required) ID of the space to backup
-                      Alternatively, you can set the STORYBLOK_SPACE_ID environment variable.
---region <region>     Region of the space. Possible values are:
-                      - 'eu' (default): EU
-                      - 'us': US
-                      - 'ap': Australia
-                      - 'ca': Canada
-                      - 'cn': China
-                      Alternatively, you can set the STORYBLOK_REGION environment variable.
---types <types>       Comma separated list of resource-types to backup (default=all).
-                      Possible values are:
-                      - 'stories'
-                      - 'collaborators'
-                      - 'components'
-                      - 'component-groups'
-                      - 'assets'
-                      - 'asset-folders'
-                      - 'internal-tags'
-                      - 'datasources'
-                      - 'space'
-                      - 'space-roles'
-                      - 'tasks'
-                      - 'activities'
-                      - 'presets'
-                      - 'field-types'
-                      - 'webhooks'
-                      - 'workflow-stages'
-                      - 'workflow-stage-changes'
-                      - 'workflows'
-                      - 'releases'
-                      - 'pipeline-branches'
-                      - 'access-tokens'
---omit-types <types>  Comma separated list of resource-types to omit.
---with-asset-files    Downloads all files (assets) of the space (default=false).
---output-dir <dir>    Directory to write the backup to (default=./.output)
-                      (ATTENTION: Will fail if the directory already exists!)
---force               Force deletion and recreation of existing output directory.
---create-zip          Create a zip file of the backup (default=false).
---zip-prefix <dir>    Prefix for the zip file. (default='backup').
-                      (The suffix will automatically be the current date.)
---verbose             Will show detailed output for every file written.
---help                Show this help
+--token <token>                (required) Personal OAuth access token created
+                               in the account settings of a Stoyblok user.
+                               (NOT the Access Token of a Space!)
+                               Alternatively, you can set the STORYBLOK_OAUTH_TOKEN environment variable.
+--space <space_id>             (required) ID of the space to backup
+                               Alternatively, you can set the STORYBLOK_SPACE_ID environment variable.
+--region <region>              Region of the space. Possible values are:
+                               - 'eu' (default): EU
+                               - 'us': US
+                               - 'ap': Australia
+                               - 'ca': Canada
+                               - 'cn': China
+                               Alternatively, you can set the STORYBLOK_REGION environment variable.
+--types <types>                Comma separated list of resource-types to backup (default=all).
+                               Possible values are:
+                               - 'stories'
+                               - 'collaborators'
+                               - 'components'
+                               - 'component-groups'
+                               - 'assets'
+                               - 'asset-folders'
+                               - 'internal-tags'
+                               - 'datasources'
+                               - 'space'
+                               - 'space-roles'
+                               - 'tasks'
+                               - 'activities'
+                               - 'presets'
+                               - 'field-types'
+                               - 'webhooks'
+                               - 'workflow-stages'
+                               - 'workflow-stage-changes'
+                               - 'workflows'
+                               - 'releases'
+                               - 'pipeline-branches'
+                               - 'access-tokens'
+--omit-types <types>           Comma separated list of resource-types to omit.
+--with-asset-files             Downloads all files (assets) of the space (default=false).
+--no-reuse-asset-connections   Blocks reuse of http(s) connections to S3 when downloading assets,
+                               this makes downloads slightly slower but can avoid errors if S3
+                               closes the connection as a request is being made (default=false).
+--output-dir <dir>             Directory to write the backup to (default=./.output)
+                               (ATTENTION: Will fail if the directory already exists!)
+--force                        Force deletion and recreation of existing output directory.
+--create-zip                   Create a zip file of the backup (default=false).
+--zip-prefix <dir>             Prefix for the zip file. (default='backup').
+                               (The suffix will automatically be the current date.)
+--verbose                      Will show detailed output for every file written.
+--help                         Show this help
 ```
 
 OAuth token, space-id and region can be set via environment variables. You can also use a `.env` file in your project root for this (see `.env.example`).
@@ -152,6 +155,7 @@ npx storyblok-backup \
     --region ap \
     --types "stories,components" \
     --with-asset-files \
+    --no-reuse-asset-connections \
     --output-dir ./my-dir \
     --force \
     --create-zip \

--- a/bin/storyblok-backup.mjs
+++ b/bin/storyblok-backup.mjs
@@ -247,7 +247,7 @@ const downloadFile = async (type, name, url) => {
 	// Should we use node:http or node:https
 	const protocol = url.startsWith('https') ? https : http
 	// Why not just use node Fetch you ask?
-	// Creating an agent for fetch requires importing the ransitive dependency undici which node's
+	// Creating an agent for fetch requires importing the transitive dependency undici which node's
 	// fetch relies on. Since we're only ever doing GETs, in the interest of keeping the explicit dependency
 	// down, just use http/https directly
 

--- a/bin/storyblok-backup.mjs
+++ b/bin/storyblok-backup.mjs
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 /* eslint-disable no-console */
 import dotenvx from '@dotenvx/dotenvx'
 import fs from 'fs'

--- a/bin/storyblok-backup.mjs
+++ b/bin/storyblok-backup.mjs
@@ -1,13 +1,13 @@
-#!/usr/bin/env node
 /* eslint-disable no-console */
+import dotenvx from '@dotenvx/dotenvx'
 import fs from 'fs'
-import { Readable } from 'stream'
+import http from 'http'
+import https from 'https'
+import minimist from 'minimist'
+import { performance } from 'perf_hooks'
+import StoryblokClient from 'storyblok-js-client'
 import { finished } from 'stream/promises'
 import zipLib from 'zip-lib'
-import minimist from 'minimist'
-import StoryblokClient from 'storyblok-js-client'
-import { performance } from 'perf_hooks'
-import dotenvx from '@dotenvx/dotenvx'
 
 const startTime = performance.now()
 
@@ -42,34 +42,37 @@ const args = minimist(process.argv.slice(2))
 if ('help' in args) {
 	console.log(`USAGE
   $ npx storyblok-backup
-  
+
 OPTIONS
-  --token <token>       (required) Personal OAuth access token created
-                        in the account settings of a Stoyblok user.
-                        (NOT the Access Token of a Space!)
-                        Alternatively, you can set the STORYBLOK_OAUTH_TOKEN environment variable.
-  --space <space_id>    (required) ID of the space to backup
-                        Alternatively, you can set the STORYBLOK_SPACE_ID environment variable.
-  --region <region>     Region of the space. Possible values are:
-                        - 'eu' (default): EU
-                        - 'us': US
-                        - 'ap': Australia
-                        - 'ca': Canada
-                        - 'cn': China
-                        Alternatively, you can set the STORYBLOK_REGION environment variable.
-  --types <types>       Comma separated list of resource-types to backup (default=all).
-                        Possible values are:
-                        - '${resourceTypes.join("'\n                      - '")}'
-  --omit-types <types>  Comma separated list of resource-types to omit.
-  --with-asset-files    Downloads all files (assets) of the space (default=false).
-  --output-dir <dir>    Directory to write the backup to (default=./.output)
-                        (ATTENTION: Will fail if the directory already exists!)
-  --force               Force deletion and recreation of existing output directory.
-  --create-zip          Create a zip file of the backup (default=false).
-  --zip-prefix <dir>    Prefix for the zip file. (default='backup').
-                        (The suffix will automatically be the current date.)
-  --verbose             Will show detailed output for every file written.
-  --help                Show this help
+  --token <token>                (required) Personal OAuth access token created
+                                 in the account settings of a Stoyblok user.
+                                 (NOT the Access Token of a Space!)
+                                 Alternatively, you can set the STORYBLOK_OAUTH_TOKEN environment variable.
+  --space <space_id>             (required) ID of the space to backup
+                                 Alternatively, you can set the STORYBLOK_SPACE_ID environment variable.
+  --region <region>              Region of the space. Possible values are:
+                                 - 'eu' (default): EU
+                                 - 'us': US
+                                 - 'ap': Australia
+                                 - 'ca': Canada
+                                 - 'cn': China
+                                 Alternatively, you can set the STORYBLOK_REGION environment variable.
+  --types <types>                Comma separated list of resource-types to backup (default=all).
+                                 Possible values are:
+                                 - '${resourceTypes.join("'\n                                 - '")}'
+  --omit-types <types>           Comma separated list of resource-types to omit.
+  --with-asset-files             Downloads all files (assets) of the space (default=false).
+  --no-reuse-asset-connections   Blocks reuse of http(s) connections to S3 when downloading assets,
+                                 this makes downloads slightly slower but can avoid errors if S3
+                                 closes the connection as a request is being made (default=false).
+  --output-dir <dir>             Directory to write the backup to (default=./.output)
+                                 (ATTENTION: Will fail if the directory already exists!)
+  --force                        Force deletion and recreation of existing output directory.
+  --create-zip                   Create a zip file of the backup (default=false).
+  --zip-prefix <dir>             Prefix for the zip file. (default='backup').
+                                 (The suffix will automatically be the current date.)
+  --verbose                      Will show detailed output for every file written.
+  --help                         Show this help
 
 MINIMAL EXAMPLE
   $ npx storyblok-backup --token 1234567890abcdef --space 12345
@@ -82,6 +85,7 @@ MAXIMAL EXAMPLE
       --types "stories,components" \\
       --omit-types "activities" \\
       --with-asset-files \\
+      --no-reuse-asset-connections \\
       --output-dir ./my-dir \\
       --force \\
       --create-zip \\
@@ -136,6 +140,7 @@ if ('omit-types' in args) {
 }
 
 const verbose = 'verbose' in args
+const shouldReuseConnection = !(args['reuse-asset-connections'] === false)
 
 const outputDir = args['output-dir'] || './.output'
 
@@ -171,7 +176,9 @@ if ('create-zip' in args) {
 	console.log(`- output zip: ${filePath}`)
 }
 console.log(`- resource types: ${resourceTypes.join(', ')}`)
-console.log(`- with asset files: ${'with-asset-files' in args ? 'yes' : 'no'}`)
+console.log(
+	`- with asset files: ${'with-asset-files' in args ? 'yes' : 'no'}, reusing http(s) connections: ${shouldReuseConnection ? 'yes' : 'no'}`
+)
 console.log(`- force output folder: ${'force' in args ? 'yes' : 'no'}`)
 console.log('')
 
@@ -234,11 +241,39 @@ const writeJson = (folder, file, content) => {
 
 // Function to download a file
 const downloadFile = async (type, name, url) => {
-	const res = await fetch(url)
 	const outputFile = `${backupDir}/${type}/${name}`
-	const fileStream = fs.createWriteStream(outputFile, { flags: 'wx' })
-	await finished(Readable.fromWeb(res.body).pipe(fileStream))
-	if (verbose) console.log(`Written file ${outputFile}`)
+
+	// Should we use node:http or node:https
+	const protocol = url.startsWith('https') ? https : http
+	// Why not just use node Fetch you ask?
+	// Creating an agent for fetch requires importing the ransitive dependency undici which node's
+	// fetch relies on. Since we're only ever doing GETs, in the interest of keeping the explicit dependency
+	// down, just use http/https directly
+
+	try {
+		await new Promise((resolve, reject) => {
+			protocol
+				.get(
+					url,
+					{ agent: new protocol.Agent({ keepAlive: shouldReuseConnection }) },
+					(res) => {
+						if (res.statusCode < 200 || res.statusCode >= 300) {
+							res.resume()
+							reject(new Error(`HTTP ${res.statusCode} ${res.statusMessage}`))
+							return
+						}
+						const fileStream = fs.createWriteStream(outputFile, {
+							flags: 'wx',
+						})
+						finished(res.pipe(fileStream)).then(resolve, reject)
+					}
+				)
+				.on('error', reject)
+		})
+		if (verbose) console.log(`Written file ${outputFile}`)
+	} catch (error) {
+		throw new Error(`Warning: failed to download ${url}: ${error.message}`)
+	}
 }
 
 // Fetch space info
@@ -380,10 +415,10 @@ if ('create-zip' in args) {
 	await zipLib
 		.archiveFolder(backupDir, filePath)
 		.then(
-			function () {
+			() => {
 				console.log(`Backup file '${filePath}' successfully created.`)
 			},
-			function (err) {
+			(err) => {
 				throw err
 			}
 		)


### PR DESCRIPTION
I've been running into an intermittent issue where backing up large numbers of assets quite quickly (link in a github action) causes the whole script to crash with a fairly opaque undici error. 

I finally tracked this down to a situation where S3 was closing TLS connections just as node was making another request.

This PR adds a flag to explicitly opt-out of keep alive connections  `--no-reuse-asset-connections`

in order to do this without adding an explicit dependency on the transitive undici (because you have to import the agent class `import { Agent } from 'undici';` to set keepalive settings) it switches the script from using node Fetch to the barebones node http/https
